### PR TITLE
Changed Voices of Wynn url to use curseforge for better speeds

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1149,7 +1149,7 @@
             "version": "1.7.1",
             "id": "vow",
             "source": "ddl",
-            "location": "https://voicesofwynn.com/download/49/jar",
+            "location": "https://mediafilez.forgecdn.net/files/5081/450/VoicesOfWynn-MC.1.20.2-v1.7.1.jar",
             "authors": [
                 {
                     "name": "kmaxi",


### PR DESCRIPTION
Curseforge seems to offer a more stable and faster connection then we have on our website right now. For this it's better to pull the mod from there which should also allow for higher download speeds.