### PR TITLE
fix(manifest): wavey capes version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -274,7 +274,7 @@
         },
         {
             "name": "Wavey Capes",
-            "version": "TzvZcb3e",
+            "version": "1.4.8",
             "source": "modrinth",
             "location": "wavey-capes",
             "authors": [


### PR DESCRIPTION
I'm Doze from discord.

The actual "version_number" from Wavey Capes is wrong, it is needed to use the actual "version_number" from the project API, not the ID.

line 758 from main.rs on the "installer" uses the property "version_number" to compare, and on Wavey Capes it is never going to be TzvZcb3e cause it's "1.4.8"