### PR TITLE
Updated voices of wynn to v 1.10.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -900,7 +900,7 @@
     	},
     	{
         	"name": "Voices of Wynn",
-        	"version": "v1.10.4",
+        	"version": "v1.10.7",
         	"source": "modrinth",
         	"location": "vow",
         	"authors": [


### PR DESCRIPTION
New features in the newer version and the old version will now sometimes spam with a null audio (like when riding sea sipper).