### PR TITLE
Changed cull leaves link from Forge to Modrinth

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -242,9 +242,9 @@
         },
         {
             "name": "Cull Leaves",
-            "version": "3.4.0",
-            "source": "ddl",
-            "location": "https://mediafilez.forgecdn.net/files/5441/879/cullleaves-fabric-3.4.0.jar",
+            "version": "3.4.0-fabric",
+            "source": "modrinth",
+            "location": "cull-leaves",
             "authors": [
                 {
                     "name": "motschen",


### PR DESCRIPTION
Updated download link from Forge to Modrinth since Immersive pack uses the same.