### PR TITLE
Changed cull leaves link from Forge to Modrinth

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -173,8 +173,8 @@
     	{
         	"name": "Cull Leaves",
         	"version": "4.0.3-fabric",
-        	"source": "ddl",
-        	"location": "https://mediafilez.forgecdn.net/files/5441/879/cullleaves-fabric-3.4.0.jar",
+        	"source": "modrinth",
+        	"location": "cull-leaves",
         	"authors": [
             	{
                 	"name": "motschen",


### PR DESCRIPTION
Updated download link from Forge to Modrinth since Immersive pack uses the same.
Also fixed weird version mishap where version was specified as 4.0.3 but 3.4.0 was actually downloaded.