### PR TITLE
Changed cull leaves link from Forge to Modrinth

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -219,8 +219,8 @@
     	{
         	"name": "Cull Leaves",
         	"version": "4.0.3-fabric",
-        	"source": "ddl",
-        	"location": "https://mediafilez.forgecdn.net/files/5441/879/cullleaves-fabric-3.4.0.jar",
+        	"source": "modrinth",
+        	"location": "cull-leaves",
         	"authors": [
             	{
                 	"name": "motschen",


### PR DESCRIPTION
Updated download link from Forge to Modrinth since Immersive pack uses the same.
Also fixed weird version mishap where version 4.0.3 was specified but 3.4.0 was downloaded (which is not meant for 1.21.4 but for 1.21.3).